### PR TITLE
Fix invalid link of thumbnail image for SNS

### DIFF
--- a/noderedcon2020/index-en.html
+++ b/noderedcon2020/index-en.html
@@ -7,7 +7,7 @@
     <meta property="og:title" content="Node-RED Con Tokyo 2020" />
     <meta property="og:type" content="Conference" />
     <meta property="og:url" content="https://nodered.jp/noderedcon2020/" />
-    <meta property="og:image" content="https://nodered.jp/noderedcon2020/img/ogimage.png" />
+    <meta property="og:image" content="https://nodered.jp/about/resources/media/node-red-icon-2.png" />
     <meta property="og:site_name" content="Node-RED Con Tokyo 2020" />
     <meta property="og:description" content="Node-RED Con Tokyo 2020 is a digital technology conference for all of Node-RED users. Lots of amazing projects, such as the latest case studies from Japan and overseas, news that you can't usually hear, and technical news." />
 

--- a/noderedcon2020/index.html
+++ b/noderedcon2020/index.html
@@ -7,7 +7,7 @@
     <meta property="og:title" content="Node-RED Con Tokyo 2020" />
     <meta property="og:type" content="Conference" />
     <meta property="og:url" content="https://nodered.jp/noderedcon2020/" />
-    <meta property="og:image" content="https://nodered.jp/noderedcon2020/img/ogimage.png" />
+    <meta property="og:image" content="https://nodered.jp/about/resources/media/node-red-icon-2.png" />
     <meta property="og:site_name" content="Node-RED Con Tokyo 2020" />
     <meta property="og:description" content="Node-RED Con Tokyo 2020は、Node-REDに関するデジタル技術カンファレンスです。国内外の最新事例、普段聞けないネタ、技術的なネタと色々と面白い企画が盛りだくさんです。" />
 


### PR DESCRIPTION
While investigating the method of Twitter card, I found that there are invalid links of the thumbnail image for SNS like the tweet.

https://twitter.com/openjsf/status/1291094260113117185

In this pull request, I changed the link to the Node-RED logo. After merging this pull request, the valid thumbnail will be used on SNS as follows.

<img width="1280" alt="スクリーンショット 2020-08-25 15 14 45" src="https://user-images.githubusercontent.com/20310935/91130686-f8d81a00-e6e6-11ea-9ae6-bc7fe3e57191.png">
