### PR TITLE
Fix countdown timer for Safari on iOS and IE on Windows

### DIFF
--- a/noderedcon2020/assets/js/main.js
+++ b/noderedcon2020/assets/js/main.js
@@ -20,7 +20,7 @@
     /* ==========================================================================
        countdown timer
        ========================================================================== */
-     jQuery('#clock').countdown(new Date('2020-10-10T13:00+0900'),function(event){
+     jQuery('#clock').countdown(new Date('2020-10-10T13:00+09:00'),function(event){
       var $this=jQuery(this).html(event.strftime(''
       +'<div class="time-entry days"><span>%-D</span> <b>:</b> Days</div> '
       +'<div class="time-entry hours"><span>%H</span> <b>:</b> Hours</div> '


### PR DESCRIPTION
When I checked the countdown timer on Safari and IE, I encountered a NaN error. I seem to use an incorrect setting for timezone.