### PR TITLE
Streaming URL has been hided

### DIFF
--- a/noderedcon2020/index-en.html
+++ b/noderedcon2020/index-en.html
@@ -362,8 +362,8 @@
             <div class="section-title-header text-center">
               <h2 class="section-title wow fadeInUp" data-wow-delay="0.2s">Session Schedules</h2>
               <p class="wow fadeInDown" data-wow-delay="0.2s">We have three tracks Business, Technology, and Hands-on workshop. <br> Being digital, you can move between sessions at your convenience. <br> Session information will be added at any time. </p>
-              <a href="https://youtu.be/ubV4g-hts-o" target="_brank">Track A Streaming URL</a><br>
-              <a href="https://youtu.be/ACx1qViN6-g" target="_brank">Track B Streaming URL</a><br><br>
+              <!-- <a href="https://youtu.be/ubV4g-hts-o" target="_brank">Track A Streaming URL</a><br> -->
+              <!-- <a href="https://youtu.be/ACx1qViN6-g" target="_brank">Track B Streaming URL</a><br><br> -->
             </div>
           </div>
         </div>

--- a/noderedcon2020/index.html
+++ b/noderedcon2020/index.html
@@ -362,8 +362,8 @@
             <div class="section-title-header text-center">
               <h2 class="section-title wow fadeInUp" data-wow-delay="0.2s">Session Schedules</h2>
               <p class="wow fadeInDown" data-wow-delay="0.2s">ビジネストラック、技術トラックの、マルチトラックでお送りします <br> デジタルなので、都合に合わせセッションを自由に行き来できます <br> セッション情報は随時追加していきます </p>
-              <a href="https://youtu.be/ubV4g-hts-o" target="_brank">Track A 視聴URL</a><br>
-              <a href="https://youtu.be/ACx1qViN6-g" target="_brank">Track B 視聴URL</a><br><br>
+              <!-- <a href="https://youtu.be/ubV4g-hts-o" target="_brank">Track A 視聴URL</a><br> -->
+              <!-- <a href="https://youtu.be/ACx1qViN6-g" target="_brank">Track B 視聴URL</a><br><br> -->
             </div>
           </div>
         </div>


### PR DESCRIPTION
参加者へは申込みのconnpass経由でURLをお伝えしているのと、あくまで申し込みをしてくれた方へのURL案内ということで、一旦Session Schedulesエリアの冒頭に置いたストリーミングURLを非表示にしました。（タイムテーブルの各セッション欄にはURL記載したままです）
カンファレンス開催後は、アーカイブ視聴できることを一人でも多くに知っていただきたいので、そのタイミングで再度表示させようと思います。

@joeartsea @1ft-seabass @kazuhitoyokoi @zuhito ご確認の上マージ願います！