### PR TITLE
Remove link for Japanese slack group

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,6 @@
                 <li><a href="https://twitter.com/nodered">Twitter</a></li>
                 <li><a href="https://discourse.nodered.org" target="_blank">フォーラム</a></li>
                 <li><a href="/slack">Slack</a></li>
-                <li><a href="https://nodered-slack.herokuapp.com/">Slack（日本ユーザ会）</a></li>
                 <li><a href="https://www.facebook.com/groups/noderedjp/">Facebookグループ（日本ユーザ会）</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Can we remove the link for the Japanese Slack group as the first step to migrate it to the official Slack?