### PR TITLE
Improve the link for the Node-RED Con

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ layout: barebones
 <div class="nodes">
     <div class="grid">
         <div class="content content-jp headline">	
-          <h3><b>Node-RED Con 2023 開催決定！　詳細は<a href="https://nrcon.nodered.org/jp/">こちら</a></b></h3>	
+          <h3><b>Node-REDカンファレンスを2023年11月10日に開催予定！　詳細は<a href="https://node-red.connpass.com/event/286923/">こちら</a></b></h3>	
         </div>
         <hr>
         <div class="content content-jp headline">


### PR DESCRIPTION
I thought the link for the connpass page is more suitable for Japanese people because the landing page is an online event. Therefore, I changed the link in this pull request.