### PR TITLE
English page 向け表示対応

### DIFF
--- a/noderedcon2024/assets/js/schedule-en.json
+++ b/noderedcon2024/assets/js/schedule-en.json
@@ -13,43 +13,43 @@
         "type": "Sponsor",
         "title": "さくらインターネットの新拠点「Blooming Camp」のご紹介",
         "abstract": "",
-        "speaker": "山坂 遼太郎",
+        "speaker": "Ryotaro Yamasaka",
         "photo": "https://nodered.jp/noderedcon2021/assets/img/speaker/noimage.png",
-        "company": "さくらインターネット"
+        "company": "SAKURA internet Inc.）"
     },
     {
         "time": "15:55-16:20",
         "type": "Keynote",
         "title": "製造業IoTでのNode-RED運用について",
         "abstract": "製造業向けIoTにてNode-REDを活用し、５０設備以上の運用実績あり。事例紹介から安定稼働のノウハウや生成AIを活用した最新の活用法を紹介させていただきます。",
-        "speaker": "三上 典秀",
+        "speaker": "Norihide Mikami",
         "photo": "./assets/img/speaker/mikami.jpg",
-        "company": "スリーアップ・テクノロジー"
+        "company": "THREE UP TECHNOLOGY"
     },
     {
         "time": "16:20-16:45",
         "type": "Breakout",
         "title": "Node-REDを活用した静岡県内企業へのIoT、デジタルツイン導入事例の紹介",
         "abstract": "静岡県工業技術研究所では、『誰でも簡単に自らの手で取り組める』をコンセプトにしたIoT実践講座を令和２年度より開催しています。教材はRaspberryPiとNode-REDを使用し、年間約30社のIoT導入を支援しています。また、IoT、DXにかかるコストや費用対効果等の導入障壁を解消するため、Node-REDとゲームエンジンのUnreal Engineを活用したデジタルツインの構築を進めています。本発表では、県内企業への導入事例について紹介します。",
-        "speaker": "岩﨑 清斗",
+        "speaker": "Kiyoto Iwasaki",
         "photo": "./assets/img/speaker/iwasaki.png",
-        "company": "静岡県工業技術研究所"
+        "company": "Industrial Research Institute of Shizuoka Prefecture"
     },
     {
         "time": "16:45-17:10",
         "type": "Breakout",
         "title": "組込エンジニアにも役立つ！Node-RED活用術",
         "abstract": "Node-REDはサーバー/クラウド分野で広く活用されていますが、組込/デバイス開発の現場では、コンパイラやデバッガ、シリアルモニタで完結するケースが多く、その利便性を実感しにくいのが現状です。そこでセンサ開発やIoTシステムを得意とする当社の開発事例を通して、組込エンジニアがNode-REDを活用するメリットをご紹介します。組込エンジニアも従来の開発手法から一歩踏み出し、Node-REDの持つ柔軟性と迅速な開発力を活かしてみませんか？",
-        "speaker": "稲玉 繁樹",
+        "speaker": "Shigeki Inatama",
         "photo": "./assets/img/speaker/inatama.jpg",
-        "company": "ミイシステム株式会社"
+        "company": "Mii System Co.,Ltd."
     },
     {
         "time": "17:10-17:35",
         "type": "Breakout",
         "title": "Node-RED MCUを使った子供向けIoTプログラミング事例",
         "abstract": "Node-RED MCUでボタン・ランプ・モーターを使ってMQTTでクイズサーバと連動する「早押しクイズマシン製作」が体験できる子供向けIoTプログラミングの事例を紹介します。",
-        "speaker": "塩路 昌宏",
+        "speaker": "Masahiro Shioji",
         "photo": "./assets/img/speaker/shioji.jpg",
         "company": "Open Creation Lab."
     },
@@ -67,7 +67,7 @@
         "type": "Breakout",
         "title": "Hazard Response Mission Pack built with Node-RED",
         "abstract": "An open-source AIoT solution with Node-RED to efficiently manage and mitigate hazard scenarios, from sensing to edge AI.",
-        "speaker": "坪井 義浩",
+        "speaker": "Yoshihiro Tsuboi",
         "photo": "./assets/img/speaker/tsuboi.jpg",
         "company": "Seeed K.K."
     },
@@ -94,7 +94,7 @@
         "type": "Breakout",
         "title": "Node-REDをライブイベントで使い倒す",
         "abstract": "前回はLINE Botを使用した実例を紹介したが、今回はLINE Botで収集したデータをQLabと連携して、ライブ会場のディスプレイにリアルタイムで更新表示する機能を開発したので、そのプロジェクトについて紹介する。また、現在作業進行中ではあるが、LINE BotのバックエンドサーバーとしてNode-REDを使用する際に、kubernetesを利用した可用性の高い環境にインストールして使用する実例も紹介したい。",
-        "speaker": "高橋ヒロキ＆小久保碧音",
+        "speaker": "Hiroki Takahashi & Aoto Kokubo",
         "photo": "./assets/img/speaker/takahashi.jpg",
         "company": "シネマトリック合同会社"
     },

--- a/noderedcon2024/index-ja.html
+++ b/noderedcon2024/index-ja.html
@@ -361,7 +361,6 @@
           <div class="col-12">
             <div class="section-title-header text-center">
               <h2 class="section-title wow fadeInUp" data-wow-delay="0.2s">Amazing Speakers</h2>
-              <p class="wow fadeInDown" data-wow-delay="0.2s">豪華スピーカー陣です！</p>
             </div>
           </div>
         </div>
@@ -562,6 +561,28 @@
               <div class="info-text">
                 <h3> <a target="_blank" href="#">Aoto Kokubo</a></h3>
                 <p>シネマトリック合同会社</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="col-lg-3 col-md-6 col-xs-12">
+            <div class="team-item wow fadeInUp" data-wow-delay="0.4s">
+              <div class="team-img">
+                <img class="img-fluid" src="assets/img/speaker/noimage.png" alt="" width="400">
+                <div class="team-overlay">
+                  <div class="overlay-social-icon text-center">
+                    <ul class="social-icons">
+                      <li> <a target="_blank" href=""><i class="lni-twitter-filled" aria-hidden="true"></i></a></li>
+                      <li> <a target="_blank" href=""><i class="lni-github" aria-hidden="true"></i></a></li>
+                      <li> <a target="_blank" href=""><i class="lni-facebook-filled" aria-hidden="true"></i></a></li>
+                      <li> <a target="_blank" href=""><i class="lni-linkedin" aria-hidden="true"></i></a></li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              <div class="info-text">
+                <h3> <a target="_blank" href="#">Ryotaro Yamasaka</a></h3>
+                <p>さくらインターネット株式会社</p>
               </div>
             </div>
           </div>

--- a/noderedcon2024/index.html
+++ b/noderedcon2024/index.html
@@ -346,7 +346,6 @@
           <div class="col-12">
             <div class="section-title-header text-center">
               <h2 class="section-title wow fadeInUp" data-wow-delay="0.2s">Amazing Speakers</h2>
-              <p class="wow fadeInDown" data-wow-delay="0.2s">豪華スピーカー陣です！</p>
             </div>
           </div>
         </div>
@@ -414,7 +413,7 @@
               </div>
               <div class="info-text">
                 <h3> <a target="_blank" href="#">Kiyoto Iwasaki</a></h3>
-                <p>静岡県工業技術研究所</p>
+                <p>Industrial Research Institute of Shizuoka Prefecture</p>
               </div>
             </div>
           </div>
@@ -458,7 +457,7 @@
               </div>
               <div class="info-text">
                 <h3> <a target="_blank" href="#">Norihide Mikami</a></h3>
-                <p>スリーアップ・テクノロジー</p>
+                <p>THREE UP TECHNOLOGY</p>
               </div>
             </div>
           </div>
@@ -480,7 +479,7 @@
               </div>
               <div class="info-text">
                 <h3> <a target="_blank" href="#">Shigeki Inatama</a></h3>
-                <p>ミイシステム株式会社</p>
+                <p>Mii System Co.,Ltd.</p>
               </div>
             </div>
           </div>
@@ -551,6 +550,28 @@
             </div>
           </div>
  
+          <div class="col-lg-3 col-md-6 col-xs-12">
+            <div class="team-item wow fadeInUp" data-wow-delay="0.4s">
+              <div class="team-img">
+                <img class="img-fluid" src="assets/img/speaker/noimage.png" alt="" width="400">
+                <div class="team-overlay">
+                  <div class="overlay-social-icon text-center">
+                    <ul class="social-icons">
+                      <li> <a target="_blank" href=""><i class="lni-twitter-filled" aria-hidden="true"></i></a></li>
+                      <li> <a target="_blank" href=""><i class="lni-github" aria-hidden="true"></i></a></li>
+                      <li> <a target="_blank" href=""><i class="lni-facebook-filled" aria-hidden="true"></i></a></li>
+                      <li> <a target="_blank" href=""><i class="lni-linkedin" aria-hidden="true"></i></a></li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              <div class="info-text">
+                <h3> <a target="_blank" href="#">Ryotaro Yamasaka</a></h3>
+                <p>SAKURA internet Inc.</p>
+              </div>
+            </div>
+          </div>
+
         </div>
       </div>
     </section>
@@ -1095,7 +1116,7 @@
          'track'
         ],
         mounted :function(){
-          axios.get('/assets/js/schedule.json')
+          axios.get('/assets/js/schedule-en.json')
             .then(response => this.sessions_g = response.data)
             .catch(error => console.log(error))
         }


### PR DESCRIPTION
English page向けにタイムテーブルデータと、Speakerデータの表記を英語に修正。セッションタイトルと概要については、こちらで勝手に翻訳して意図が変わってしまうとまずいので日本語のままとした。